### PR TITLE
fix: если поток ответа имеет указатель, то перед чтением его надо установить в начало

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -121,7 +121,11 @@ class Client implements ClientInterface
     {
         $authParams = ['auth' => [$this->login, $this->password], 'json' => $data];
         $response = $this->client->request($method, $url, $authParams);
+        $stream = $response->getBody();
+        if ($stream->isSeekable()) {
+            $stream->seek(0);
+        }
 
-        return json_decode($response->getBody()->getContents(), true);
+        return json_decode($stream->getContents(), true);
     }
 }


### PR DESCRIPTION
Может случиться так, что в методе `request()` ответ уже будет прочитан (например, для записи в лог по шаблону `{res_body}`, если клиент будет инициализирован соответствующе). В итоге без возврата указателя в начало, `$response->getBody()->getContents()` вернёт пустой результат.